### PR TITLE
Add State.ProtectType

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -73,7 +73,7 @@ function State.new(InitialState)
 
 			for Key, Value in next, Dictionary do
 				if (type(Value) == "table") then
-					NewDictionary[Key] = self.__joinDictionary(NewDictionary[Key], Value)
+					NewDictionary[Key] = self:__joinDictionary(NewDictionary[Key], Value)
 					continue
 				end
 
@@ -107,7 +107,7 @@ end
 	Return a deep copy of the current stored state
 --]]
 function State:GetState()
-	return self.__joinDictionary(self.__state, {})
+	return self:__joinDictionary(self.__state, {})
 end
 
 --[[
@@ -131,7 +131,7 @@ function State:Set(Key, Value)
 	end
 
 	if (type(Value) == "table") then
-		Value = self.__joinDictionary(OldState[Key], Value)
+		Value = self:__joinDictionary(OldState[Key], Value)
 	end
 
 	if (OldState[Key] ~= Value) then


### PR DESCRIPTION
# State.ProtectType

## What is it?
State.ProtectType is a boolean propety that (when enabled, of course) prevents accidentally changing the type of a value that a key is storing. When enabled, you cannot overwrite a key that holds a string with a number value, etc. Using `:RawSet()` will ignore State.ProtectType in situations where you want to override this protection.


**It is disabled by default in order to ensure backwards compatibility.**

## Why?
I like to be certain that state values will be a specific type without needing to do checks whenever I get them- it saves a lot of worrying because you know it can't have accidentally been set to NaN or something like that. It gives your top level code more clarity and keeps it concise, while also giving you better peace of mind.

## Usage:
```Lua
local State = BasicState.new({
	NestedTable = {
		Key = "string type value"
	}
})
State.ProtectType = true

State:Set("NestedTable",{Key = 123}) -- Errors due to nested type mismatch
```

### Explanations for whoever code reviews this:

I added a small snippet into `:Set()` that does a type check on your values to protect you from changing types. It avoids checking when the original value is nil, because there you are allowed to initialize that key to any type, and then subsequent calls to that key will be checked against that newly set value's type.

I moved `JoinDictionary()` into `State.__joinDictionary()` so that the function can have access to `self` so that it can check the value of `self.ProtectType`. I then altered all calls to this new function location. Lastly, I added a small snippet into the function that handles this type protection for the nested values in your State.


-------------


Hopefully you'll find some ways for me to improve this! I want to make sure we implement this as best we can. Feel free to DM me anywhere about this if you don't want to bloat this thread/devforum thread.