### PR TITLE
Vastly Improve Memory Usage of GetChangedSignal()

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -88,6 +88,16 @@ function State.new(InitialState)
 	self.Changed = self.__changeEvent.Event
 
 	--[[
+		Handle firing bindables created from State:GetChangedSignal
+	--]]
+	self.Changed:Connect(function(OldState, ChangedKey)
+		local Signal = self.__bindables[ChangedKey]
+		if Signal then
+			Signal:Fire(self:Get(ChangedKey), OldState[ChangedKey], OldState)
+		end
+	end)
+
+	--[[
 		Return the new completed BasicState instance
 	--]]
 	return self
@@ -198,15 +208,15 @@ end
 	RBXScriptConnection
 --]]
 function State:GetChangedSignal(Key)
-	local Signal = Instance.new("BindableEvent")
 
-	self.Changed:Connect(function(OldState, ChangedKey)
-		if (Key == ChangedKey) then
-			Signal:Fire(self:Get(Key), OldState[Key], OldState)
-		end
-	end)
+	local Signal = self.__bindables[Key]
+	if Signal then
+		return Signal.Event
+	end
 
-	self.__bindables[#self.__bindables + 1] = Signal
+	Signal = Instance.new("BindableEvent")
+
+	self.__bindables[Key] = Signal
 	return Signal.Event
 end
 


### PR DESCRIPTION
Let's take a look at a simple example- you have a few connections to one key change in various places of your codebase, and one connection to a different key.
```Lua
State:GetChangedSignal(Key):Connect(function()
	-- code
end)
State:GetChangedSignal(Key):Connect(function()
	-- more code
end)
State:GetChangedSignal(Key):Connect(function()
	-- even more code
end)
State:GetChangedSignal(Key):Connect(function()
	-- yup, more code
end)

State:GetChangedSignal(DifferentKey):Connect(function()
	-- code
end)
```

The current module will result in 5 BindableEvents and 5 Connections, since each call creates a new BindableEvent and Connection inside the module, plus the additional 5 Connections in our example code to bring the total to 10 Connections.

My changed module results in 2 BindableEvents and 1 Connection. The module has 1 Connection for *all* ChangedSignals, regardless of key, and 1 BindableEvent per requested Key with all subsequent calls to that Key sharing that single Instance. With our 5 in the top layer, that brings our Connection total to just 6.

This heavily saves on memory, and even helps performance noticeably.