### PR TITLE
Add State:__tostring()

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -359,6 +359,50 @@ function State:Roact(Component, Keys)
 end
 
 --[[
+	Returns a string format of the current state instead of the class.
+
+	Added by @Kevinwkz in v0.2.1
+]]
+function State:__tostring()
+	local str = "\n"
+	local spaces = 2
+	
+	local function parseString(s)
+		return type(s) == "string" and "\"" .. s .. "\"" or s
+	end
+	
+	local function stringify(tbl, stack)
+		stack = stack or 1
+		local s = ""
+		local space = ((" "):rep(spaces)):rep(stack)
+
+		local length = 0
+		for _, _ in next , tbl do
+			length += 1
+		end
+
+		local i = 1
+		for k, v in next, tbl do
+			local key = ("%s[%s]:"):format(space, parseString(k))
+			local comma = i < length and "," or ""
+			if type(v) ~= "table" then
+				s ..= ("%s %s%s\n"):format(key, parseString(v), comma)
+			else
+				s ..= ("%s {\n%s%s}%s\n"):format(key, stringify(v, stack + 1), space, comma)
+			end
+			i += 1
+		end
+		if stack == 1 then
+			str ..= s
+		end
+		return s
+	end
+	stringify(self.__state)
+
+	return ("\n(State): {%s}"):format(str)
+end
+
+--[[
 	Return the State table from the module to allow users to construct new
 	BasicState instances
 --]]


### PR DESCRIPTION
State:__tostring()
===========
This update provides a better tree output for when a state is printed.

### So let's use this code as an example:
```lua
local State = BasicState.new({
	Location = "Mountain",
	Greetings = {
		Place = "Welcome to the Mountain!",
		Roblox = "Hey Roblox!",
		Me = "Hi Kevin!"
	}
})

print(State)

State:SetState({
	Location = "City",
	array = {1, 2, 34, 56},
	Greetings = {
		Place = "Welcome to the City!"
	}
})

print(State)
```

### This will be the output without __tostring():
<img src="https://i.imgur.com/evXeKzM.png">

### And this is with __tostring() added:
<img src="https://i.imgur.com/KjW4HTe.png">