### PR TITLE
Corrected Roact version and bumped Wally to use the latest

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Checkout Repositry
+      - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           submodules: true
@@ -34,8 +34,8 @@ jobs:
 
       - name: Build Test Project
         shell: bash
-        run: rojo build test.project.json -o unit-tests.rbxlx
+        run: rojo build test.project.json -o unit-tests.rbxl
 
       - name: Run Unit Tests
         shell: bash
-        run: run-in-roblox --place unit-tests.rbxlx --script test-runner.server.lua
+        run: run-in-roblox --place unit-tests.rbxl --script test-runner.server.lua

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-*.rbxm*
-*.rbxl*
+*.rbx*
 
 roblox.toml
-testez.toml
 *.tsbuildinfo
 
 /dist

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 
 [dependencies]
-BasicState = "csqrl/BasicState@^0.2.3"
+BasicState = "csqrl/BasicState@^0.2.4"
 ```
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 
 [dependencies]
-BasicState = "csqrl/BasicState@^0.2.3"
+BasicState = "csqrl/BasicState@^0.2.4"
 ```
 
 ```sh

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "^6.2.0" }
 run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "^0.3.0" }
-wally = { source = "UpliftGames/wally", version="^0.2.1" }
+wally = { source = "UpliftGames/wally", version="^0.3.1" }

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "^6.2.0" }
-run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "^0.3.0" }
-wally = { source = "UpliftGames/wally", version="^0.3.1" }
+rojo = { source = "rojo-rbx/rojo", version = "=7.0.0" }
+run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "=0.3.0" }
+wally = { source = "upliftgames/wally", version="=0.3.1" }

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,7 +1,0 @@
-[package]
-name = "BasicState"
-author = "csqrl"
-license = "MIT"
-version = "0.2.3"
-dependencies_root = "packages"
-content_root = "src"

--- a/wally.toml
+++ b/wally.toml
@@ -10,4 +10,4 @@ realm = "shared"
 
 [dev-dependencies]
 TestEZ = "roblox/testez@^0.4.1"
-Roact = "roblox/roact@^1.4.3"
+Roact = "roblox/roact@^1.4.2"

--- a/wally.toml
+++ b/wally.toml
@@ -1,11 +1,11 @@
 [package]
 name = "csqrl/basicstate"
 description = "Really simple state management"
-version = "0.2.3"
+version = "0.2.4"
 license = "MIT"
 authors = ["csqrl (https://csqrl.dev)"]
-contributors = ["boatbomber", "rimuy", "gaffal"]
-registry = "https://github.com/UpliftGames/wally-index"
+contributors = ["boatbomber", "rimuy", "gaffal", "mkargus"]
+registry = "https://github.com/upliftgames/wally-index"
 realm = "shared"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #10

The wally config file is calling for a version of Roact that does not exist.
Also bumped Wally to use the latest version since it will require the user to update.